### PR TITLE
Fixed bug - prefixes that are subsets of others

### DIFF
--- a/scripts/eagle_renumber.py
+++ b/scripts/eagle_renumber.py
@@ -78,14 +78,14 @@ sch_part_tag_re = re.compile(
       '<part name="{}(.+?)".*value="([\.0-9]+)([{}]?)(.*?)".*[/]?>'.\
             format(prefix, ''.join(known_unit_prefixes.keys()))
             )
-sch_instance_tag_re = re.compile('<instance part="{}(.+?)".*'.format(prefix))
-sch_pinref_tag_re = re.compile('<pinref part="{}(.+?)".*'.format(prefix))
+sch_instance_tag_re = re.compile('<instance part="{}([0-9]+?)".*'.format(prefix))
+sch_pinref_tag_re = re.compile('<pinref part="{}([0-9]+?)".*'.format(prefix))
 
 brd_element_tag_re = re.compile(
       '<element name="{}(.+?)".*value="([\.0-9]+)([{}]?)(.*?)".*[/]?>'.\
             format(prefix, ''.join(known_unit_prefixes.keys()))
             )
-brd_contactref_tag_re = re.compile('<contactref element="{}(.+?)".*'.format(prefix))
+brd_contactref_tag_re = re.compile('<contactref element="{}([0-9]+?)".*'.format(prefix))
 
 numbers = set()
 values = collections.Counter()

--- a/scripts/eagle_renumber.py
+++ b/scripts/eagle_renumber.py
@@ -78,14 +78,14 @@ sch_part_tag_re = re.compile(
       '<part name="{}(.+?)".*value="([\.0-9]+)([{}]?)(.*?)".*[/]?>'.\
             format(prefix, ''.join(known_unit_prefixes.keys()))
             )
-sch_instance_tag_re = re.compile('<instance part="{}([0-9]+?)".*'.format(prefix))
-sch_pinref_tag_re = re.compile('<pinref part="{}([0-9]+?)".*'.format(prefix))
+sch_instance_tag_re = re.compile('<instance part="{}([\.0-9]+?)".*'.format(prefix))
+sch_pinref_tag_re = re.compile('<pinref part="{}([\.0-9]+?)".*'.format(prefix))
 
 brd_element_tag_re = re.compile(
       '<element name="{}(.+?)".*value="([\.0-9]+)([{}]?)(.*?)".*[/]?>'.\
             format(prefix, ''.join(known_unit_prefixes.keys()))
             )
-brd_contactref_tag_re = re.compile('<contactref element="{}([0-9]+?)".*'.format(prefix))
+brd_contactref_tag_re = re.compile('<contactref element="{}([\.0-9]+?)".*'.format(prefix))
 
 numbers = set()
 values = collections.Counter()


### PR DESCRIPTION
Example: enter prefix 'L', part exists named 'LED1'
Error thrown because group matching thinks 'ED1' is
a number, which errors when cast to an int

Solution: Strict number matching after prefix. Instead
of accepting any characters (.+?) , only accept numbers ([0-9]+?)

Pull requesting because I've never done regex and I want to make sure I don't mess it up for everyone else.
