### PR TITLE
Fixing grid default in Eagle 8.2 (and possibly earlier)

### DIFF
--- a/scr/eagle.scr
+++ b/scr/eagle.scr
@@ -4,8 +4,10 @@
 
 BRD:
 
-Grid Default On;
+Grid On;
+Grid Inch
 Grid .1;
+Grid Alt Inch
 Grid Alt .01;
 Change Width 0.010;
 Change Font vector;

--- a/scr/eagle.scr
+++ b/scr/eagle.scr
@@ -5,18 +5,18 @@
 BRD:
 
 Grid On;
-Grid Inch
-Grid .1;
-Grid Alt Inch
-Grid Alt .01;
-Change Width 0.010;
+Grid mil
+Grid 100;
+Grid Alt mil
+Grid Alt 10;
+Change Width 10;
 Change Font vector;
 Change Align bottom-center;
 
 Change Ratio 12%;
 Change Shape round;
-Change Drill .016;
-Change Isolate .012;
+Change Drill 16;
+Change Isolate 12;
 
 #Menu Add Change Copy Delete Display Grid Group Move Name Quit Rect \
 #     Route Script Show Signal Split Text Value Via Window ';'  Wire Write Edit;


### PR DESCRIPTION
On my mac the current eagle.scr file opened all BRD units in mils, which was clearly problematic. Changing these lines seemed to fix the issue. It would be good if someone else could confirm the problem and check the fix before merging.